### PR TITLE
revert scrape name

### DIFF
--- a/roles/prometheus/files/prometheus.yml
+++ b/roles/prometheus/files/prometheus.yml
@@ -53,7 +53,7 @@ scrape_configs:
           chain: 'westend'
           node_type: 'boot'
 
-  - job_name: amforc
+  - job_name: ibpfederation
     metrics_path: /federate
     honor_labels: true
     scheme: https


### PR DESCRIPTION
With the use of member label new members can append to the existing scrape job list instead of creating a new one.
Due to this I reverted the name of the scrape job back.