### PR TITLE
Add Polkadotters Prometheus federation

### DIFF
--- a/roles/prometheus/files/prometheus.yml
+++ b/roles/prometheus/files/prometheus.yml
@@ -110,3 +110,14 @@ scrape_configs:
     static_configs:
       - targets:
           - ibp-prometheus.radiumblock.co
+
+  - job_name: polkadotters
+    metrics_path: /federate
+    honor_labels: true
+    scheme: https
+    params:
+      match[]:
+        - '{job="substrate"}'
+    static_configs:
+      - targets:
+        - 202.37.148.106:19090


### PR DESCRIPTION
This PR adds the Prometheus federation endpoint - the current IP address is only a temporary solution because once we have the firewall and do the proper networking setup, we will put the federation in front of our own domain. 