### PR TITLE
update gatotech's metrics endpoint

### DIFF
--- a/roles/prometheus/files/prometheus.yml
+++ b/roles/prometheus/files/prometheus.yml
@@ -76,7 +76,7 @@ scrape_configs:
         - '{job="substrate"}'
     static_configs:
       - targets:
-          - "138.59.133.242:9090"
+          - ibp-metrics.gatotech.network
 
   - job_name: dwellir
     metrics_path: /713173e6-ff3f-46ab-b245-b41da8f717d3/federate


### PR DESCRIPTION
Hello @tugytur !

Please consider this change to replace our federation endpoint IP address with a secured link (port 443).

Many thanks!

Milos

